### PR TITLE
Update encodings-as-record.z3

### DIFF
--- a/experiments/encodings-as-record.z3
+++ b/experiments/encodings-as-record.z3
@@ -15,19 +15,20 @@
 )))
 
 (declare-datatypes () ((Encoding
-    (mk-enc (channel Channel) (type FieldType) (agg AggFunc))
+    (mk-enc (chan Channel) (type FieldType) (agg AggFunc))
 )))
 
 ; I'm trying to write a function to get the channel from an encoding
-;(define-fun channel (e Encoding) Channel
-;)
+(define-fun channel ((e Encoding)) Channel
+  (chan e)
+)
 
 (define-sort Set (T) (Array T Bool))
 
 (declare-const mark Marktype)
 (declare-const encodings (Set Encoding))
 
-;(assert (exists ((e Encoding) (= (channel e) X))))
+(assert (exists ((e Encoding)) (= (chan e) X)))
 
 (check-sat)
 (get-model)


### PR DESCRIPTION
don't need a function, can use name of the property. Looks like can't be same name even if capitalization different, so I abbreviated channel as chan.